### PR TITLE
Fix wrong org name in github workflows

### DIFF
--- a/.github/workflows/build-push-kubeai.yml
+++ b/.github/workflows/build-push-kubeai.yml
@@ -12,7 +12,7 @@ on:
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: substratusai/kubeai
+  IMAGE_NAME: kubeai-project/kubeai
 
 jobs:
   kubeai:

--- a/.github/workflows/build-push-model-loader.yml
+++ b/.github/workflows/build-push-model-loader.yml
@@ -12,7 +12,7 @@ on:
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: substratusai/kubeai-model-loader
+  IMAGE_NAME: kubeai-project/kubeai-model-loader
 
 jobs:
   kubeai-model-loader:


### PR DESCRIPTION
Replace old organization name with the new one from github workflows.