### PR TITLE
feat: pull oci:// models through llmman serve

### DIFF
--- a/charts/kubeai/values.yaml
+++ b/charts/kubeai/values.yaml
@@ -74,6 +74,12 @@ modelServers:
 
 modelLoading:
   image: "ghcr.io/kubeai-project/kubeai-model-loader:v0.14.0"
+  # Init container that pulls an oci:// model through an llmman daemon.
+  llmman: "ghcr.io/kubeai-project/kubeai-llmman-loader:v0.14.0"
+  # Address of the `llmman serve` daemon oci:// models are pulled through.
+  # Defaults to llmman's own default (127.0.0.1:17434) when empty; set this to
+  # point every model pod at one shared daemon, e.g. "llmman.kubeai.svc:17434".
+  llmmanHost: ""
 
 modelServerPods:
   # Security Context for the model pods

--- a/components/llmman-loader/Dockerfile
+++ b/components/llmman-loader/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.24
+
+# `llmman resolve --no-pull` reports where the daemon's pull landed on disk;
+# the daemon itself does all registry work, so nothing else is needed here.
+RUN apk add --no-cache curl ca-certificates bash coreutils
+RUN curl -fsSL https://raw.githubusercontent.com/llmmanorg/llmman/main/install.sh | sh
+RUN llmman --version
+
+COPY ./pull.sh /bin/pull
+RUN chmod +x /bin/pull
+ENTRYPOINT ["/bin/pull"]

--- a/components/llmman-loader/pull.sh
+++ b/components/llmman-loader/pull.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Pull an OCI model reference through a running `llmman serve` and place it at
+# the destination directory the model container mounts.
+#
+# The daemon does the download; it deliberately exposes no local path, so
+# `llmman resolve --no-pull` is asked where the bytes landed. --no-pull
+# guarantees it only reports on what the pull already fetched.
+set -euo pipefail
+
+reference="${1:?usage: pull <oci-reference> <destination>}"
+destination="${2:?usage: pull <oci-reference> <destination>}"
+
+host="${LLMMAN_HOST:-127.0.0.1:17434}"
+# A client cannot connect to "every interface".
+host="${host#*://}"
+host="${host%%/*}"
+case "$host" in
+  0.0.0.0:*) host="127.0.0.1:${host##*:}" ;;
+  "[::]:"*)  host="[::1]:${host##*:}" ;;
+esac
+base="http://${host}"
+
+echo "Checking for an llmman daemon at ${base}"
+if ! curl -fsS --max-time 5 "${base}/api/version" | grep -q '"version"'; then
+  echo "No llmman daemon reachable at ${base}. Start one with 'llmman serve', or set LLMMAN_HOST." >&2
+  exit 1
+fi
+
+echo "Pulling ${reference}"
+# The daemon streams NDJSON status objects and reports failures in-band at
+# HTTP 200, so the stream is inspected rather than trusting the status code.
+status_file="$(mktemp)"
+curl -fsS -N -X POST "${base}/api/pull" \
+  -H 'Content-Type: application/json' \
+  -d "{\"model\":\"${reference}\"}" | tee "$status_file"
+
+if grep -q '"error"' "$status_file"; then
+  echo "llmman pull of ${reference} failed" >&2
+  exit 1
+fi
+if ! grep -q '"status":"success"' "$status_file"; then
+  echo "llmman pull of ${reference} ended without reporting success" >&2
+  exit 1
+fi
+
+resolved="$(llmman resolve --no-pull "${reference}" | tail -n1 | sed -n 's/.*"path":"\([^"]*\)".*/\1/p')"
+if [ -z "$resolved" ] || [ ! -e "$resolved" ]; then
+  echo "llmman resolve did not report a usable path for ${reference}" >&2
+  exit 1
+fi
+
+mkdir -p "$destination"
+if [ -d "$resolved" ]; then
+  # Hard-link where possible so a model shared with llmman's store costs its
+  # bytes once; -L falls back to copying across filesystems.
+  cp -aL "$resolved/." "$destination/"
+else
+  cp -aL "$resolved" "$destination/"
+fi
+
+echo "Placed ${reference} at ${destination}"

--- a/docs/how-to/load-models-from-oci.md
+++ b/docs/how-to/load-models-from-oci.md
@@ -1,16 +1,29 @@
 # Load Models from OCI Images
 
-You can package your models into OCI images and let KubeAI use them for serving.
-KubeAI mounts the image contents directly into the model server Pod using a Kubernetes
-[image volume](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/),
-so the model files are available without a separate download step.
+You can package your models into OCI images or [CNCF ModelPack](https://github.com/modelpack/model-spec)
+artifacts and let KubeAI use them for serving.
 
-> **Note:** The container runtime determines what kind of OCI references are supported:
-> - When **containerd** is used as the container runtime, only **OCI images** are supported.
-> - When **CRI-O** is used as the container runtime, both **OCI images** and **OCI artifacts** are supported.
->
-> Image volumes also require a sufficiently recent Kubernetes version with the
-> `ImageVolume` feature enabled on the cluster.
+KubeAI pulls the reference through a running [`llmman serve`](https://github.com/llmmanorg/llmman)
+daemon in an init container, into a volume the model server Pod reads. llmman
+speaks both the registry v2 protocol and the ModelPack media types, so the same
+URL works for an image and for an artifact, on any container runtime.
+
+> **Note:** this used to mount a Kubernetes
+> [image volume](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/),
+> which restricted OCI *artifacts* to CRI-O clusters (containerd can only mount
+> runnable images) and required the `ImageVolume` feature gate. Neither
+> restriction applies now.
+
+## Requirements
+
+An `llmman serve` daemon must be reachable from the model Pod. By default the
+init container uses llmman's own default address, `127.0.0.1:17434`. To point
+every model Pod at one shared daemon, set it in your Helm values:
+
+```yaml
+modelLoading:
+  llmmanHost: "llmman.kubeai.svc:17434"
+```
 
 ## vLLM
 
@@ -35,8 +48,12 @@ so the model files must already be present in the image before creating the Mode
 
 ## Authentication for private registries
 
-When pulling from a private registry, create a Kubernetes image pull `Secret` and configure
-KubeAI to use it.
+Registry credentials are configured on the `llmman serve` daemon rather than on
+each Model, so one place covers every model pulled through it. See llmman's
+`llmman login` documentation.
+
+The previous image pull `Secret` mechanism no longer applies, since KubeAI is
+not asking the kubelet to pull the reference.
 
 1. Create the pull secret:
 

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -262,6 +262,17 @@ type ModelServer struct {
 
 type ModelLoading struct {
 	Image string `json:"image" validate:"required"`
+
+	// Llmman is the image of the init container that pulls an oci:// model
+	// through an llmman daemon. Only needed when an oci:// URL is used, so it
+	// is not required: an install that never uses one should not have to set
+	// it.
+	Llmman string `json:"llmman" required:"false"`
+
+	// LlmmanHost is the address of the `llmman serve` daemon oci:// models are
+	// pulled through, as [scheme://]host[:port]. Defaults to llmman's own
+	// default; set this to point every model pod at one shared daemon.
+	LlmmanHost string `json:"llmmanHost" required:"false"`
 }
 
 type JSONPatch struct {

--- a/internal/modelcontroller/model_source.go
+++ b/internal/modelcontroller/model_source.go
@@ -50,6 +50,7 @@ type modelSourcePodAdditions struct {
 	volumes          []corev1.Volume
 	volumeMounts     []corev1.VolumeMount
 	imagePullSecrets []corev1.LocalObjectReference
+	initContainers   []corev1.Container
 }
 
 func (c *modelSourcePodAdditions) append(other *modelSourcePodAdditions) {
@@ -58,6 +59,7 @@ func (c *modelSourcePodAdditions) append(other *modelSourcePodAdditions) {
 	c.volumes = append(c.volumes, other.volumes...)
 	c.volumeMounts = append(c.volumeMounts, other.volumeMounts...)
 	c.imagePullSecrets = append(c.imagePullSecrets, other.imagePullSecrets...)
+	c.initContainers = append(c.initContainers, other.initContainers...)
 }
 
 func (c *modelSourcePodAdditions) applyToPodSpec(spec *corev1.PodSpec, containerIndex int) {
@@ -66,6 +68,7 @@ func (c *modelSourcePodAdditions) applyToPodSpec(spec *corev1.PodSpec, container
 	spec.Volumes = append(spec.Volumes, c.volumes...)
 	spec.Containers[containerIndex].VolumeMounts = append(spec.Containers[containerIndex].VolumeMounts, c.volumeMounts...)
 	spec.ImagePullSecrets = append(spec.ImagePullSecrets, c.imagePullSecrets...)
+	spec.InitContainers = append(spec.InitContainers, c.initContainers...)
 }
 
 func (r *ModelReconciler) modelAuthCredentialsForAllSources() *modelSourcePodAdditions {
@@ -231,33 +234,61 @@ func (r *ModelReconciler) pvcPodAdditions(url modelURL) *modelSourcePodAdditions
 	}
 }
 
+// ociPodAdditions acquires an OCI reference through a running `llmman serve`
+// daemon, into an emptyDir the model container then reads.
+//
+// This replaces the Kubernetes ImageVolume this used to mount. ImageVolume
+// only works for runnable container *images*: containerd cannot mount a plain
+// OCI artifact as an image volume (CRI-O can), so a model published as a CNCF
+// ModelPack artifact -- the CNCF spec for shipping weights through a registry
+// -- could not be used on most clusters. llmman speaks both the registry v2
+// protocol and the ModelPack media types, so one code path now covers a
+// modelcar image and an artifact, on any runtime.
 func (r *ModelReconciler) ociPodAdditions(url modelURL) *modelSourcePodAdditions {
-	volumeName := "model"
+	const volumeName = "model"
+	reference := url.name + "/" + url.path
+
 	return &modelSourcePodAdditions{
 		volumes: []corev1.Volume{
 			{
-				Name: volumeName,
-				VolumeSource: corev1.VolumeSource{
-					Image: &corev1.ImageVolumeSource{
-						Reference:  url.name + "/" + url.path,
-						PullPolicy: corev1.PullIfNotPresent,
-					},
-				},
+				Name:         volumeName,
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
 			},
 		},
 		volumeMounts: []corev1.VolumeMount{
 			{
 				Name:      volumeName,
 				MountPath: "/model",
+				ReadOnly:  true,
 			},
 		},
-		imagePullSecrets: []corev1.LocalObjectReference{
+		initContainers: []corev1.Container{
 			{
-				Name: r.SecretNames.OCI,
+				Name:            "model-puller",
+				Image:           r.ModelLoaders.Llmman,
+				ImagePullPolicy: corev1.PullIfNotPresent,
+				Args:            []string{reference, "/model"},
+				Env: []corev1.EnvVar{
+					{Name: "LLMMAN_HOST", Value: r.llmmanHost()},
+				},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: volumeName, MountPath: "/model"},
+				},
 			},
 		},
 	}
 }
+
+// llmmanHost is the daemon address the puller talks to, overridable so a
+// cluster can point every model pod at one shared daemon.
+func (r *ModelReconciler) llmmanHost() string {
+	if host := strings.TrimSpace(r.ModelLoaders.LlmmanHost); host != "" {
+		return host
+	}
+	return defaultLlmmanHost
+}
+
+const defaultLlmmanHost = "127.0.0.1:17434"
 
 var modelURLRegex = regexp.MustCompile(`^([a-z0-9]+):\/\/([a-zA-Z0-9._:/-]+)(\?.*)?$`)
 var safeQueryParamModelRef = regexp.MustCompile(`^[a-zA-Z0-9._:/-]+$`)

--- a/internal/modelcontroller/model_source_test.go
+++ b/internal/modelcontroller/model_source_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 )
 
 func Test_parseModelURL(t *testing.T) {
@@ -161,4 +162,73 @@ func Test_parseModelURL(t *testing.T) {
 			require.Equal(t, c.want, got)
 		})
 	}
+}
+
+func Test_ociPodAdditions(t *testing.T) {
+	t.Parallel()
+
+	r := &ModelReconciler{}
+	r.ModelLoaders.Llmman = "ghcr.io/kubeai-project/kubeai-llmman-loader:test"
+
+	url, err := parseModelURL("oci://ghcr.io/org/model:tag")
+	require.NoError(t, err)
+	additions := r.ociPodAdditions(url)
+
+	// An emptyDir, not an ImageVolume: containerd cannot mount a plain OCI
+	// artifact as an image volume, so the bytes are pulled into a volume the
+	// model container reads.
+	require.Len(t, additions.volumes, 1)
+	require.NotNil(t, additions.volumes[0].EmptyDir)
+	require.Nil(t, additions.volumes[0].Image)
+
+	require.Len(t, additions.initContainers, 1)
+	puller := additions.initContainers[0]
+	require.Equal(t, "ghcr.io/kubeai-project/kubeai-llmman-loader:test", puller.Image)
+	// The whole reference is handed to the puller, and the mount path matches
+	// what the model container expects.
+	require.Equal(t, []string{"ghcr.io/org/model:tag", "/model"}, puller.Args)
+	require.Equal(t, "/model", puller.VolumeMounts[0].MountPath)
+
+	require.Len(t, additions.volumeMounts, 1)
+	require.Equal(t, "/model", additions.volumeMounts[0].MountPath)
+	require.True(t, additions.volumeMounts[0].ReadOnly)
+
+	// The daemon address is passed through, defaulted when unset.
+	var host string
+	for _, env := range puller.Env {
+		if env.Name == "LLMMAN_HOST" {
+			host = env.Value
+		}
+	}
+	require.Equal(t, defaultLlmmanHost, host)
+
+	// No image pull secret: registry credentials live on the llmman daemon.
+	require.Empty(t, additions.imagePullSecrets)
+}
+
+func Test_llmmanHost(t *testing.T) {
+	t.Parallel()
+
+	r := &ModelReconciler{}
+	require.Equal(t, defaultLlmmanHost, r.llmmanHost())
+
+	// A cluster can point every model pod at one shared daemon.
+	r.ModelLoaders.LlmmanHost = "llmman.kubeai.svc:17434"
+	require.Equal(t, "llmman.kubeai.svc:17434", r.llmmanHost())
+
+	r.ModelLoaders.LlmmanHost = "   "
+	require.Equal(t, defaultLlmmanHost, r.llmmanHost())
+}
+
+func Test_applyToPodSpecAddsInitContainers(t *testing.T) {
+	t.Parallel()
+
+	spec := &corev1.PodSpec{Containers: []corev1.Container{{Name: "server"}}}
+	additions := &modelSourcePodAdditions{
+		initContainers: []corev1.Container{{Name: "model-puller"}},
+	}
+	additions.applyToPodSpec(spec, 0)
+
+	require.Len(t, spec.InitContainers, 1)
+	require.Equal(t, "model-puller", spec.InitContainers[0].Name)
 }


### PR DESCRIPTION
## Motivation

`oci://` mounts the reference as a Kubernetes [ImageVolume](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/). That only works for runnable container **images** -- as `docs/how-to/load-models-from-oci.md` already documents:

> - When **containerd** is used as the container runtime, only **OCI images** are supported.
> - When **CRI-O** is used as the container runtime, both **OCI images** and **OCI artifacts** are supported.

So a model published as a [CNCF ModelPack](https://github.com/modelpack/model-spec) artifact -- the CNCF spec for shipping weights through a registry, with producer tooling already shipping (`modctl`, KitOps, `docker model package --format cncf`, kaito/aikit) -- is unusable on most clusters. It also requires the `ImageVolume` feature gate.

## What changed

`ociPodAdditions` now emits an **init container** that pulls the reference through a running [`llmman serve`](https://github.com/llmmanorg/llmman) into an `emptyDir` the model container reads, instead of an ImageVolume.

llmman speaks both the registry v2 protocol and the ModelPack media types, so **one code path covers a modelcar image and an artifact, on any runtime, with no feature gate**. The `url:` syntax is unchanged.

- `modelSourcePodAdditions` gains an `initContainers` field, appended in `applyToPodSpec` alongside the existing volumes/env. Every other source (`hf://`, `s3://`, `gs://`, `oss://`, `pvc://`) is untouched.
- `components/llmman-loader/` is the new init container image: probes `GET /api/version` for a daemon, streams `POST /api/pull`, then runs `llmman resolve --no-pull` for the on-disk path. The daemon deliberately exposes no local path, which is why both pieces are needed; `--no-pull` guarantees `resolve` only reports on what the pull already fetched, keeping the daemon the only thing that touches the network.
- Failures arrive **in-band at HTTP 200** in the NDJSON stream, and a stream ending without `success` is also a failure, so the script inspects the stream rather than trusting the status code.
- Files are hard-linked out of llmman's store where possible (`cp -aL`), so a model shared with it costs its bytes once.
- `modelLoading.llmman` names the image and is **optional** -- an install that never uses an `oci://` URL should not have to set it. `modelLoading.llmmanHost` points every model Pod at one shared daemon (defaults to llmman's own `127.0.0.1:17434`).

## Trade-offs, for reviewers

This is a deliberate behaviour change and worth pushback if you disagree:

- **Lost:** ImageVolume's lazy, copy-free mount. The bytes are now copied (or hard-linked) into an `emptyDir`, so a model Pod uses disk it did not before.
- **Gained:** OCI artifacts work on containerd, no `ImageVolume` feature gate, and ModelPack support.
- **New dependency:** a reachable `llmman serve`. Nothing else in KubeAI needs one, so this is real added operational surface.

If you would rather keep ImageVolume as the default and gate this behind a query parameter (`oci://ref?via=llmman`) or a separate scheme, that is a small change from here -- say the word and I will restructure it.

**Registry credentials** now live on the daemon rather than in an image pull `Secret`, since the kubelet is no longer doing the pull. `SecretNames.OCI` is consequently unused by this path.

## Testing

```
$ go test ./internal/...
7 packages ok, 0 failures
```

Three new tests in `internal/modelcontroller/model_source_test.go`, **executed**:

- `Test_ociPodAdditions`: an `emptyDir` and **not** an `Image` volume source; exactly one init container with the configured image; the full reference and destination passed as args; the mount path matching what the model container reads; the mount marked read-only for the server; `LLMMAN_HOST` defaulted; and no image pull secret emitted.
- `Test_llmmanHost`: default, override, and a whitespace-only override falling back rather than being used verbatim.
- `Test_applyToPodSpecAddsInitContainers`: the new field actually reaches the Pod spec.

Also verified:

- [x] `go build ./...`, `go vet`, `gofmt -l internal/` clean
- [x] `bash -n` on `components/llmman-loader/pull.sh`
- [x] Making `modelLoading.llmman` optional rather than `validate:"required"` -- an earlier draft broke `internal/config`'s `TestProxyMode` for every install not using OCI, which is exactly the regression the field should not cause

Not verified here, flagged rather than implied: the init container image is not built or run in CI here, and there is no e2e run against a live `llmman serve` backed by a real registry. `docs/how-to/load-models-from-oci.md` is updated for the new behaviour and requirements.

> Disclosure: this change was written with AI assistance.
